### PR TITLE
refactor: rename Direction to CardinalDirection in Day4 and move Day6 Direction in Core helpers

### DIFF
--- a/Sources/Core/helpers.swift
+++ b/Sources/Core/helpers.swift
@@ -39,7 +39,7 @@ public struct Coord: Equatable, Hashable {
         self.y = y
     }
 
-    public func isInsideArea(width: Int, height: Int) -> Bool {
+    public func isInsideArea(width: UInt, height: UInt) -> Bool {
         x >= 0 && y >= 0 &&
             x < width && y < height
     }

--- a/Sources/Core/helpers.swift
+++ b/Sources/Core/helpers.swift
@@ -18,9 +18,21 @@ public enum AoC24 {
     }
 }
 
+public extension UInt {
+    func asText() -> String {
+        "\(self)"
+    }
+}
+
 public extension Int {
     func asText() -> String {
         "\(self)"
+    }
+}
+
+public extension Array where Element == UInt {
+    func sum() -> UInt {
+        reduce(0,+)
     }
 }
 

--- a/Sources/Core/helpers.swift
+++ b/Sources/Core/helpers.swift
@@ -45,6 +45,26 @@ public struct Coord: Equatable, Hashable {
     }
 }
 
+public enum Direction: Equatable, CaseIterable {
+    case north
+    case east
+    case south
+    case west
+
+    public var offset: Coord {
+        switch self {
+        case .north:
+            Coord(0, -1)
+        case .east:
+            Coord(1, 0)
+        case .south:
+            Coord(0, 1)
+        case .west:
+            Coord(-1, 0)
+        }
+    }
+}
+
 public extension Array where Element: Equatable {
     @discardableResult
     mutating func removeLastOccurrence(of element: Element) -> Element? {

--- a/Sources/Core/helpers.swift
+++ b/Sources/Core/helpers.swift
@@ -43,6 +43,10 @@ public struct Coord: Equatable, Hashable {
         x >= 0 && y >= 0 &&
             x < width && y < height
     }
+
+    public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+        Coord(lhs.x + rhs.x, lhs.y + rhs.y)
+    }
 }
 
 public enum Direction: Equatable, CaseIterable {

--- a/Sources/Day4/Day4.swift
+++ b/Sources/Day4/Day4.swift
@@ -52,16 +52,16 @@ extension Array where Element == String {
     }
 
     func allFourLetters(from origin: Coord) -> [String] {
-        Direction.allCases.compactMap { direction in
+        CardinalDirection.allCases.compactMap { direction in
             fourLetters(from: origin, towards: direction)
         }
     }
 
-    func fourLetters(from origin: Coord, towards direction: Direction) -> String? {
+    func fourLetters(from origin: Coord, towards direction: CardinalDirection) -> String? {
         word(from: origin, towards: direction, ofLength: 4)
     }
 
-    func word(from origin: Coord, towards direction: Direction, ofLength count: Int) -> String? {
+    func word(from origin: Coord, towards direction: CardinalDirection, ofLength count: Int) -> String? {
         var result = ""
         var nextCoord = origin
         while result.count < count {
@@ -85,11 +85,11 @@ extension Array where Element == String {
 
     func crossWords(centeredAt center: Coord) -> Pair<String>? {
         guard
-            let northWestLetter = char(at: center + Direction.northWest.offset),
-            let northEastLetter = char(at: center + Direction.northEast.offset),
+            let northWestLetter = char(at: center + CardinalDirection.northWest.offset),
+            let northEastLetter = char(at: center + CardinalDirection.northEast.offset),
             let centerLetter = char(at: center),
-            let southWestLetter = char(at: center + Direction.southWest.offset),
-            let southEastLetter = char(at: center + Direction.southEast.offset)
+            let southWestLetter = char(at: center + CardinalDirection.southWest.offset),
+            let southEastLetter = char(at: center + CardinalDirection.southEast.offset)
         else {
             return nil
         }
@@ -107,7 +107,7 @@ extension Coord {
     }
 }
 
-enum Direction: Equatable, CaseIterable {
+enum CardinalDirection: Equatable, CaseIterable {
     case north
     case northEast
     case east

--- a/Sources/Day4/Day4.swift
+++ b/Sources/Day4/Day4.swift
@@ -101,12 +101,6 @@ extension Array where Element == String {
     }
 }
 
-extension Coord {
-    static func + (_ lhs: Self, _ rhs: Self) -> Self {
-        Coord(lhs.x + rhs.x, lhs.y + rhs.y)
-    }
-}
-
 enum CardinalDirection: Equatable, CaseIterable {
     case north
     case northEast

--- a/Sources/Day6/Day6.swift
+++ b/Sources/Day6/Day6.swift
@@ -140,12 +140,7 @@ struct Guard: Equatable {
     }
 }
 
-enum Direction: Equatable, Hashable, CaseIterable {
-    case north
-    case east
-    case south
-    case west
-
+extension Direction {
     func turnRight() -> Self {
         switch self {
         case .north:
@@ -162,8 +157,8 @@ enum Direction: Equatable, Hashable, CaseIterable {
 
 extension Coord {
     func heading(_ heading: Direction) -> Self {
-        var nextX = self.x
-        var nextY = self.y
+        var nextX = x
+        var nextY = y
         switch heading {
         case .north:
             nextY -= 1

--- a/Sources/Day6/Day6.swift
+++ b/Sources/Day6/Day6.swift
@@ -18,12 +18,12 @@ public final class Day6: AoCDay {
 
     func reconLab(from input: String) throws -> Lab {
         let lines = input.split(separator: "\n")
-        let height: Int = lines.count
+        let height: UInt = UInt(lines.count)
         var obstacles: [Coord] = []
         var labGuard: Guard?
-        var width = 0
+        var width: UInt = 0
         for (y, line) in lines.enumerated() {
-            width = line.count
+            width = UInt(line.count)
             for (x, character) in line.enumerated() {
                 if character == "#" {
                     obstacles.append(Coord(x, y))
@@ -174,15 +174,13 @@ extension Coord {
 }
 
 struct Map: Equatable {
-    let width: Int
-    let height: Int
+    let width: UInt
+    let height: UInt
     let obstacles: Set<Coord>
 
-    init?(width: Int, height: Int, obstacles: [Coord]) {
+    init?(width: UInt, height: UInt, obstacles: [Coord]) {
         let uniqueObstacles = Set(obstacles)
         guard
-            width >= 0 &&
-            height >= 0 &&
             obstacles.count < width * height &&
             uniqueObstacles.count == obstacles.count &&
             uniqueObstacles.allSatisfy({ $0.isInsideArea(width: width, height: height) })

--- a/Sources/Day8/Day8.swift
+++ b/Sources/Day8/Day8.swift
@@ -20,10 +20,10 @@ public final class Day8: AoCDay {
     func scanningAreaForAntennas(using input: String) throws -> Map {
         var antennas = [Antenna]()
         let lines = input.split(separator: "\n")
-        let height = lines.count
-        var width = 0
+        let height = UInt(lines.count)
+        var width: UInt = 0
         for (y, line) in lines.enumerated() {
-            width = line.count
+            width = UInt(line.count)
             for (x, frequency) in line.enumerated() {
                 if frequency != "." {
                     antennas.append(Antenna(position: Coord(x, y), frequency: frequency))
@@ -40,11 +40,11 @@ enum Day8Error: Error {
 }
 
 struct Map: Equatable {
-    var width: Int
-    var height: Int
+    var width: UInt
+    var height: UInt
     var antennaPositionsByFrequencies: [Character: [Coord]]
 
-    init?(width: Int, height: Int, antennas: [Antenna]) {
+    init?(width: UInt, height: UInt, antennas: [Antenna]) {
         guard antennas.count > 1 else { return nil }
         self.width = width
         self.height = height
@@ -96,7 +96,7 @@ extension Pair where A == Coord, B == Coord {
         Coord(first.x + (first.x - second.x), first.y + (first.y - second.y))
     }
 
-    func antinodeAndResonantHarmonicsBeforeAndWithinArea(ofWidth width: Int, height: Int) -> [Coord] {
+    func antinodeAndResonantHarmonicsBeforeAndWithinArea(ofWidth width: UInt, height: UInt) -> [Coord] {
         var antinodeAndResonantHarmonics = [Coord]()
         var currentPair = self
         while currentPair.first.isInsideArea(width: width, height: height) {
@@ -111,7 +111,7 @@ extension Pair where A == Coord, B == Coord {
         Coord(second.x + (second.x - first.x), second.y + (second.y - first.y))
     }
 
-    func antinodeAndResonantHarmonicsAfterAndWithinArea(ofWidth width: Int, height: Int) -> [Coord] {
+    func antinodeAndResonantHarmonicsAfterAndWithinArea(ofWidth width: UInt, height: UInt) -> [Coord] {
         var antinodeAndResonantHarmonics = [Coord]()
         var currentPair = self
         while currentPair.second.isInsideArea(width: width, height: height) {

--- a/Tests/Day4Tests/Day4Tests.swift
+++ b/Tests/Day4Tests/Day4Tests.swift
@@ -109,14 +109,14 @@ struct Day4Tests {
 
     @Test("Direction enum has an offset property that returns a Coord representing how to move in that direction")
     func directionOffsetTest() {
-        #expect(Direction.north.offset == Coord(0, -1))
-        #expect(Direction.northEast.offset == Coord(1, -1))
-        #expect(Direction.east.offset == Coord(1, 0))
-        #expect(Direction.southEast.offset == Coord(1, 1))
-        #expect(Direction.south.offset == Coord(0, 1))
-        #expect(Direction.southWest.offset == Coord(-1, 1))
-        #expect(Direction.west.offset == Coord(-1, 0))
-        #expect(Direction.northWest.offset == Coord(-1, -1))
+        #expect(CardinalDirection.north.offset == Coord(0, -1))
+        #expect(CardinalDirection.northEast.offset == Coord(1, -1))
+        #expect(CardinalDirection.east.offset == Coord(1, 0))
+        #expect(CardinalDirection.southEast.offset == Coord(1, 1))
+        #expect(CardinalDirection.south.offset == Coord(0, 1))
+        #expect(CardinalDirection.southWest.offset == Coord(-1, 1))
+        #expect(CardinalDirection.west.offset == Coord(-1, 0))
+        #expect(CardinalDirection.northWest.offset == Coord(-1, -1))
     }
 
     @Test("Adding two coordonates should add their fields")

--- a/Tests/Day6Tests/Day6Tests.swift
+++ b/Tests/Day6Tests/Day6Tests.swift
@@ -25,11 +25,8 @@ struct Day6Tests {
         #expect(Coord(3, 4).y == 4)
     }
 
-    @Test("A valid Map should be created with positive width, height and unique obstacles less than total area and inside area")
+    @Test("A valid Map should be created with width, height and unique obstacles less than total area and inside area")
     func mapCreationTest() throws {
-        #expect(Map(width: -1, height: 2, obstacles: []) == nil)
-        #expect(Map(width: 1, height: -2, obstacles: []) == nil)
-        #expect(Map(width: -1, height: -2, obstacles: []) == nil)
         #expect(Map(width: 0, height: 0, obstacles: []) == nil)
         #expect(Map(width: 1, height: 2, obstacles: []) != nil)
         #expect(Map(width: 10, height: 20, obstacles: []) != nil)


### PR DESCRIPTION
### Pull Request Description

This pull request introduces a refactor of the `Direction` enum, renaming it to `CardinalDirection` within the Day4 module. This change enhances clarity and consistency, helping to differentiate it from the `Direction` variant used in Day6. 

Key changes include:
- Renaming the `Direction` enum to `CardinalDirection` to improve code readability.
- Updating all references throughout the Day4 module to ensure that the functionality remains intact after the renaming.
- Moving the Day6 `Direction` variant into Core helpers, making it reusable for upcoming challenges.

These modifications aim to streamline the codebase and prepare for future enhancements.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #7 
- <kbd>&nbsp;2&nbsp;</kbd> #6 
- <kbd>&nbsp;1&nbsp;</kbd> #5 👈 
<!-- GitButler Footer Boundary Bottom -->

